### PR TITLE
feat: add config option 'verbose'

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,17 +130,16 @@ vim.keymap.set("n", "<leader>cd", t.extensions.zoxide.list)
 ```lua
 {
   prompt_title = "[ Zoxide List ]",
-
   -- Zoxide list command with score
   list_command = "zoxide query -ls",
+  -- Print "directory changed to..." messages
+  verbose = true,
   mappings = {
     default = {
       action = function(selection)
         vim.cmd.edit(selection.path)
       end,
-      after_action = function(selection)
-        print("Directory changed to " .. selection.path)
-      end
+      after_action = z_utils.print_directory_changed(),
     },
     ["<C-s>"] = { action = z_utils.create_basic_command("split") },
     ["<C-v>"] = { action = z_utils.create_basic_command("vsplit") },
@@ -161,6 +160,7 @@ vim.keymap.set("n", "<leader>cd", t.extensions.zoxide.list)
       action = function(selection)
         vim.cmd.tcd(selection.path)
       end
+      after_action = z_utils.print_directory_changed(),
     },
   }
 }

--- a/lua/telescope/_extensions/zoxide/config.lua
+++ b/lua/telescope/_extensions/zoxide/config.lua
@@ -6,17 +6,16 @@ local config = {}
 
 local default_config = {
   prompt_title = "[ Zoxide List ]",
-
   -- Zoxide list command with score
   list_command = "zoxide query -ls",
+  -- Print "directory changed to..." messages
+  verbose = true,
   mappings = {
     default = {
       action = function(selection)
         vim.cmd.cd(selection.path)
       end,
-      after_action = function(selection)
-        print("Directory changed to " .. selection.path)
-      end
+      after_action = z_utils.print_directory_changed(),
     },
     ["<C-s>"] = { action = z_utils.create_basic_command("split") },
     ["<C-v>"] = { action = z_utils.create_basic_command("vsplit") },
@@ -36,7 +35,8 @@ local default_config = {
     ["<C-t>"] = {
       action = function(selection)
         vim.cmd.tcd(selection.path)
-      end
+      end,
+      after_action = z_utils.print_directory_changed(),
     },
   }
 }

--- a/lua/telescope/_extensions/zoxide/utils.lua
+++ b/lua/telescope/_extensions/zoxide/utils.lua
@@ -6,4 +6,13 @@ utils.create_basic_command = function(command)
   end
 end
 
+utils.print_directory_changed = function()
+  return function(selection)
+    local config = require("telescope._extensions.zoxide.config").get_config()
+    if config.verbose then
+      print("Directory changed to " .. selection.path)
+    end
+  end
+end
+
 return utils


### PR DESCRIPTION
"Directory changed to..." messages are only printed when `verbose` is
set to `true`