### PR TITLE
feat: add `path_display` support with a default value

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,10 +169,8 @@ vim.keymap.set("n", "<leader>cd", t.extensions.zoxide.list)
   path_display = function(opts, path)
     local transformed_path = vim.trim(path)
     -- Replace home with ~
-    local home = vim.uv.os_homedir()
-    if home and vim.startswith(path, home) then
-      transformed_path = "~/" .. Path:new(path):make_relative(home)
-    end
+    local home = (vim.uv or vim.loop).os_homedir()
+    transformed_path = home and transformed_path:gsub("^" .. vim.pesc(home), "~") or transformed_path
     -- Truncate
     local calc_result_length = function(truncate_len)
       local status = get_status(vim.api.nvim_get_current_buf())

--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ vim.keymap.set("n", "<leader>cd", t.extensions.zoxide.list)
     return transformed_path, path_style
   end,
 
-  -- Terminal previewer using `eza`/`tree`
+  -- Terminal previewer using `eza`/`tree`, can be disabled via `previewer = false`
   previewer =  previewers.new_termopen_previewer({
     title = "Tree Preview",
     get_command = function(entry)

--- a/README.md
+++ b/README.md
@@ -131,6 +131,8 @@ vim.keymap.set("n", "<leader>cd", t.extensions.zoxide.list)
 {
   prompt_title = "[ Zoxide List ]",
 
+  replace_home_with_tilde = true,
+
   -- Zoxide list command with score
   list_command = "zoxide query -ls",
   mappings = {

--- a/README.md
+++ b/README.md
@@ -133,6 +133,8 @@ vim.keymap.set("n", "<leader>cd", t.extensions.zoxide.list)
 
   replace_home_with_tilde = true,
 
+  previewer = true,
+
   -- Zoxide list command with score
   list_command = "zoxide query -ls",
   mappings = {

--- a/README.md
+++ b/README.md
@@ -130,9 +130,9 @@ vim.keymap.set("n", "<leader>cd", t.extensions.zoxide.list)
 ```lua
 {
   prompt_title = "[ Zoxide List ]",
-
   replace_home_with_tilde = true,
-
+  truncate = true,
+  filename_highlight = true,
   previewer = true,
 
   -- Zoxide list command with score

--- a/README.md
+++ b/README.md
@@ -131,7 +131,6 @@ vim.keymap.set("n", "<leader>cd", t.extensions.zoxide.list)
 {
   prompt_title = "[ Zoxide List ]",
   replace_home_with_tilde = true,
-  truncate = true,
   filename_highlight = true,
   previewer = true,
 

--- a/README.md
+++ b/README.md
@@ -130,40 +130,6 @@ vim.keymap.set("n", "<leader>cd", t.extensions.zoxide.list)
 ```lua
 {
   prompt_title = "[ Zoxide List ]",
-  -- set to `nil` to disable previewer
-  previewer = previewers.vim_buffer_cat.new,
-  show_score = true,
-  -- see `:help telescope.defaults.path_display`
-  path_display = function(opts, path)
-    local transformed_path = vim.trim(path)
-    -- replace home with ~
-    local home = vim.loop.os_homedir()
-    if home and vim.startswith(path, home) then
-      transformed_path = "~/" .. Path:new(path):make_relative(home)
-    end
-    -- truncate
-    -- copy from: https://github.com/nvim-telescope/telescope.nvim/blob/bfcc7d5c6f12209139f175e6123a7b7de6d9c18a/lua/telescope/utils.lua#L198
-    local calc_result_length = function(truncate_len)
-      local status = get_status(vim.api.nvim_get_current_buf())
-      local len = vim.api.nvim_win_get_width(status.layout.results.winid) - status.picker.selection_caret:len() - 2
-      return type(truncate_len) == "number" and len - truncate_len or len
-    end
-    local truncate_len = nil
-    if opts.__length == nil then
-      opts.__length = calc_result_length(truncate_len)
-    end
-    if opts.__prefix == nil then
-      opts.__prefix = 0
-    end
-    transformed_path = truncate(transformed_path, opts.__length - opts.__prefix, nil, -1)
-    -- filename highlighting
-    local tail = utils.path_tail(path)
-    local path_style = {
-      { { 0, #transformed_path - #tail }, "Comment" },
-      -- { { #transformed_path - #tail, #transformed_path }, "Constant" },
-    }
-    return transformed_path, path_style
-  end,
 
   -- Zoxide list command with score
   list_command = "zoxide query -ls",
@@ -196,7 +162,43 @@ vim.keymap.set("n", "<leader>cd", t.extensions.zoxide.list)
         vim.cmd.tcd(selection.path)
       end
     },
-  }
+  },
+
+  -- Set to false to disable default terminal tree previewer using `eza`/`tree`
+  -- You can also use your own previewer via `require("telescope").extensions.zoxide.list({ previewer = previewers.vim_buffer_cat.new({}) })`
+  use_default_previewer = true,
+  show_score = true,
+  -- See `:help telescope.defaults.path_display`
+  path_display = function(opts, path)
+    local transformed_path = vim.trim(path)
+    -- Replace home with ~
+    local home = vim.loop.os_homedir()
+    if home and vim.startswith(path, home) then
+      transformed_path = "~/" .. Path:new(path):make_relative(home)
+    end
+    -- Truncate
+    -- Copied from: https://github.com/nvim-telescope/telescope.nvim/blob/bfcc7d5c6f12209139f175e6123a7b7de6d9c18a/lua/telescope/utils.lua#L198
+    local calc_result_length = function(truncate_len)
+      local status = get_status(vim.api.nvim_get_current_buf())
+      local len = vim.api.nvim_win_get_width(status.layout.results.winid) - status.picker.selection_caret:len() - 2
+      return type(truncate_len) == "number" and len - truncate_len or len
+    end
+    local truncate_len = nil
+    if opts.__length == nil then
+      opts.__length = calc_result_length(truncate_len)
+    end
+    if opts.__prefix == nil then
+      opts.__prefix = 0
+    end
+    transformed_path = truncate(transformed_path, opts.__length - opts.__prefix, nil, -1)
+    -- Filename highlighting
+    local tail = utils.path_tail(path)
+    local path_style = {
+      { { 0, #transformed_path - #tail }, "Comment" },
+      -- { { #transformed_path - #tail, #transformed_path }, "Constant" },
+    }
+    return transformed_path, path_style
+  end,
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ vim.keymap.set("n", "<leader>cd", t.extensions.zoxide.list)
     return transformed_path, path_style
   end,
 
-  -- Terminal previewer using `eza`/`tree`, set to nil to disable
+  -- Terminal previewer using `eza`/`tree`
   previewer =  previewers.new_termopen_previewer({
     title = "Tree Preview",
     get_command = function(entry)

--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ vim.keymap.set("n", "<leader>cd", t.extensions.zoxide.list)
   path_display = function(opts, path)
     local transformed_path = vim.trim(path)
     -- Replace home with ~
-    local home = vim.loop.os_homedir()
+    local home = vim.uv.os_homedir()
     if home and vim.startswith(path, home) then
       transformed_path = "~/" .. Path:new(path):make_relative(home)
     end
@@ -191,7 +191,7 @@ vim.keymap.set("n", "<leader>cd", t.extensions.zoxide.list)
     local tail = utils.path_tail(path)
     local path_style = {
       { { 0, #transformed_path - #tail }, "Comment" },
-      -- { { #transformed_path - #tail, #transformed_path }, "Constant" },
+      -- { { #transformed_path - #tail, #transformed_path }, "TelescopeResultsIdentifier" },
     }
     return transformed_path, path_style
   end,

--- a/README.md
+++ b/README.md
@@ -130,9 +130,40 @@ vim.keymap.set("n", "<leader>cd", t.extensions.zoxide.list)
 ```lua
 {
   prompt_title = "[ Zoxide List ]",
-  replace_home_with_tilde = true,
-  filename_highlight = true,
-  previewer = true,
+  -- set to `nil` to disable previewer
+  previewer = previewers.vim_buffer_cat.new,
+  show_score = true,
+  -- see `:help telescope.defaults.path_display`
+  path_display = function(opts, path)
+    local transformed_path = vim.trim(path)
+    -- replace home with ~
+    local home = vim.loop.os_homedir()
+    if home and vim.startswith(path, home) then
+      transformed_path = "~/" .. Path:new(path):make_relative(home)
+    end
+    -- truncate
+    -- copy from: https://github.com/nvim-telescope/telescope.nvim/blob/bfcc7d5c6f12209139f175e6123a7b7de6d9c18a/lua/telescope/utils.lua#L198
+    local calc_result_length = function(truncate_len)
+      local status = get_status(vim.api.nvim_get_current_buf())
+      local len = vim.api.nvim_win_get_width(status.layout.results.winid) - status.picker.selection_caret:len() - 2
+      return type(truncate_len) == "number" and len - truncate_len or len
+    end
+    local truncate_len = nil
+    if opts.__length == nil then
+      opts.__length = calc_result_length(truncate_len)
+    end
+    if opts.__prefix == nil then
+      opts.__prefix = 0
+    end
+    transformed_path = truncate(transformed_path, opts.__length - opts.__prefix, nil, -1)
+    -- filename highlighting
+    local tail = utils.path_tail(path)
+    local path_style = {
+      { { 0, #transformed_path - #tail }, "Comment" },
+      -- { { #transformed_path - #tail, #transformed_path }, "Constant" },
+    }
+    return transformed_path, path_style
+  end,
 
   -- Zoxide list command with score
   list_command = "zoxide query -ls",

--- a/README.md
+++ b/README.md
@@ -168,7 +168,9 @@ vim.keymap.set("n", "<leader>cd", t.extensions.zoxide.list)
     -- Truncate
     local calc_result_length = function(truncate_len)
       local status = get_status(vim.api.nvim_get_current_buf())
-      local len = vim.api.nvim_win_get_width(status.layout.results.winid) - status.picker.selection_caret:len() - 2
+      -- Compatibility with telescope.nvim 0.1.4
+      local results_win = vim.tbl_get(status, "layout", "results", "winid") or status.results_win
+      local len = vim.api.nvim_win_get_width(results_win) - status.picker.selection_caret:len() - 2
       return type(truncate_len) == "number" and len - truncate_len or len
     end
     local truncate_len = nil

--- a/README.md
+++ b/README.md
@@ -185,11 +185,10 @@ vim.keymap.set("n", "<leader>cd", t.extensions.zoxide.list)
       opts.__prefix = 0
     end
     transformed_path = truncate(transformed_path, opts.__length - opts.__prefix, nil, -1)
-    -- Filename highlighting
+    -- Dim parent directories
     local tail = utils.path_tail(path)
     local path_style = {
       { { 0, #transformed_path - #tail }, "Comment" },
-      -- { { #transformed_path - #tail, #transformed_path }, "TelescopeResultsIdentifier" },
     }
     return transformed_path, path_style
   end,

--- a/README.md
+++ b/README.md
@@ -192,52 +192,6 @@ vim.keymap.set("n", "<leader>cd", t.extensions.zoxide.list)
     }
     return transformed_path, path_style
   end,
-
-  -- Terminal previewer using `eza`/`tree`, can be disabled via `previewer = false`
-  previewer =  previewers.new_termopen_previewer({
-    title = "Tree Preview",
-    get_command = function(entry)
-      local p = from_entry.path(entry, true, false)
-      if p == nil or p == "" then
-        return
-      end
-      local command
-      local ignore_glob = ".DS_Store|.git|.svn|.idea|.vscode|node_modules"
-      if vim.fn.executable("eza") == 1 then
-        command = {
-          "eza",
-          "--all",
-          "--level=2",
-          "--group-directories-first",
-          "--ignore-glob=" .. ignore_glob,
-          "--git-ignore",
-          "--tree",
-          "--color=always",
-          "--color-scale",
-          "all",
-          "--icons=always",
-          "--long",
-          "--time-style=iso",
-          "--git",
-          "--no-permissions",
-          "--no-user",
-        }
-      else
-        command = { "tree", "-a", "-L", "2", "-I", ignore_glob, "-C", "--dirsfirst" }
-      end
-      return utils.flatten({ command, "--", utils.path_expand(p) })
-    end,
-    scroll_fn = function(self, direction)
-      if not self.state then
-        return
-      end
-      local input = vim.api.nvim_replace_termcodes(direction > 0 and "<C-e>" or "<C-y>", true, false, true)
-      local count = math.abs(direction)
-      vim.api.nvim_win_call(vim.fn.bufwinid(self.state.termopen_bufnr), function()
-        vim.cmd([[normal! ]] .. count .. input)
-      end)
-    end,
-  }),
 }
 ```
 

--- a/lua/telescope/_extensions/zoxide/config.lua
+++ b/lua/telescope/_extensions/zoxide/config.lua
@@ -78,7 +78,7 @@ local default_config = {
     return transformed_path, path_style
   end,
 
-  -- Terminal previewer using `eza`/`tree`
+  -- Terminal previewer using `eza`/`tree`, can be disabled via `previewer = false`
   previewer =  previewers.new_termopen_previewer({
     title = "Tree Preview",
     get_command = function(entry)

--- a/lua/telescope/_extensions/zoxide/config.lua
+++ b/lua/telescope/_extensions/zoxide/config.lua
@@ -3,7 +3,6 @@ local utils = require('telescope.utils')
 local previewers = require("telescope.previewers")
 local from_entry = require("telescope.from_entry")
 local z_utils = require("telescope._extensions.zoxide.utils")
-local Path = require("plenary.path")
 
 local truncate = require("plenary.strings").truncate
 local get_status = require("telescope.state").get_status
@@ -51,10 +50,8 @@ local default_config = {
   path_display = function(opts, path)
     local transformed_path = vim.trim(path)
     -- Replace home with ~
-    local home = vim.uv.os_homedir()
-    if home and vim.startswith(path, home) then
-      transformed_path = "~/" .. Path:new(path):make_relative(home)
-    end
+    local home = (vim.uv or vim.loop).os_homedir()
+    transformed_path = home and transformed_path:gsub("^" .. vim.pesc(home), "~") or transformed_path
     -- Truncate
     local calc_result_length = function(truncate_len)
       local status = get_status(vim.api.nvim_get_current_buf())

--- a/lua/telescope/_extensions/zoxide/config.lua
+++ b/lua/telescope/_extensions/zoxide/config.lua
@@ -78,7 +78,7 @@ local default_config = {
     return transformed_path, path_style
   end,
 
-  -- Terminal previewer using `eza`/`tree`, set to nil to disable
+  -- Terminal previewer using `eza`/`tree`
   previewer =  previewers.new_termopen_previewer({
     title = "Tree Preview",
     get_command = function(entry)

--- a/lua/telescope/_extensions/zoxide/config.lua
+++ b/lua/telescope/_extensions/zoxide/config.lua
@@ -9,6 +9,8 @@ local default_config = {
 
   replace_home_with_tilde = true,
 
+  previewer = true,
+
   -- Zoxide list command with score
   list_command = "zoxide query -ls",
   mappings = {

--- a/lua/telescope/_extensions/zoxide/config.lua
+++ b/lua/telescope/_extensions/zoxide/config.lua
@@ -6,9 +6,9 @@ local config = {}
 
 local default_config = {
   prompt_title = "[ Zoxide List ]",
-
   replace_home_with_tilde = true,
-
+  truncate = true,
+  filename_highlight = true,
   previewer = true,
 
   -- Zoxide list command with score

--- a/lua/telescope/_extensions/zoxide/config.lua
+++ b/lua/telescope/_extensions/zoxide/config.lua
@@ -7,7 +7,6 @@ local config = {}
 local default_config = {
   prompt_title = "[ Zoxide List ]",
   replace_home_with_tilde = true,
-  truncate = true,
   filename_highlight = true,
   previewer = true,
 

--- a/lua/telescope/_extensions/zoxide/config.lua
+++ b/lua/telescope/_extensions/zoxide/config.lua
@@ -51,7 +51,7 @@ local default_config = {
   path_display = function(opts, path)
     local transformed_path = vim.trim(path)
     -- Replace home with ~
-    local home = vim.loop.os_homedir()
+    local home = vim.uv.os_homedir()
     if home and vim.startswith(path, home) then
       transformed_path = "~/" .. Path:new(path):make_relative(home)
     end
@@ -73,7 +73,7 @@ local default_config = {
     local tail = utils.path_tail(path)
     local path_style = {
       { { 0, #transformed_path - #tail }, "Comment" },
-      -- { { #transformed_path - #tail, #transformed_path }, "Constant" },
+      -- { { #transformed_path - #tail, #transformed_path }, "TelescopeResultsIdentifier" },
     }
     return transformed_path, path_style
   end,

--- a/lua/telescope/_extensions/zoxide/config.lua
+++ b/lua/telescope/_extensions/zoxide/config.lua
@@ -1,14 +1,50 @@
+local Path = require("plenary.path")
 local builtin = require("telescope.builtin")
 local utils = require('telescope.utils')
+local previewers = require("telescope.previewers")
 local z_utils = require("telescope._extensions.zoxide.utils")
+
+local truncate = require("plenary.strings").truncate
+local get_status = require("telescope.state").get_status
 
 local config = {}
 
 local default_config = {
   prompt_title = "[ Zoxide List ]",
-  replace_home_with_tilde = true,
-  filename_highlight = true,
-  previewer = true,
+  -- set to `nil` to disable previewer
+  previewer = previewers.vim_buffer_cat.new,
+  show_score = true,
+  -- see `:help telescope.defaults.path_display`
+  path_display = function(opts, path)
+    local transformed_path = vim.trim(path)
+    -- replace home with ~
+    local home = vim.loop.os_homedir()
+    if home and vim.startswith(path, home) then
+      transformed_path = "~/" .. Path:new(path):make_relative(home)
+    end
+    -- truncate
+    -- copy from: https://github.com/nvim-telescope/telescope.nvim/blob/bfcc7d5c6f12209139f175e6123a7b7de6d9c18a/lua/telescope/utils.lua#L198
+    local calc_result_length = function(truncate_len)
+      local status = get_status(vim.api.nvim_get_current_buf())
+      local len = vim.api.nvim_win_get_width(status.layout.results.winid) - status.picker.selection_caret:len() - 2
+      return type(truncate_len) == "number" and len - truncate_len or len
+    end
+    local truncate_len = nil
+    if opts.__length == nil then
+      opts.__length = calc_result_length(truncate_len)
+    end
+    if opts.__prefix == nil then
+      opts.__prefix = 0
+    end
+    transformed_path = truncate(transformed_path, opts.__length - opts.__prefix, nil, -1)
+    -- filename highlighting
+    local tail = utils.path_tail(path)
+    local path_style = {
+      { { 0, #transformed_path - #tail }, "Comment" },
+      -- { { #transformed_path - #tail, #transformed_path }, "Constant" },
+    }
+    return transformed_path, path_style
+  end,
 
   -- Zoxide list command with score
   list_command = "zoxide query -ls",

--- a/lua/telescope/_extensions/zoxide/config.lua
+++ b/lua/telescope/_extensions/zoxide/config.lua
@@ -1,5 +1,7 @@
 local builtin = require("telescope.builtin")
 local utils = require('telescope.utils')
+local previewers = require("telescope.previewers")
+local from_entry = require("telescope.from_entry")
 local z_utils = require("telescope._extensions.zoxide.utils")
 local Path = require("plenary.path")
 
@@ -44,9 +46,6 @@ local default_config = {
     },
   },
 
-  -- Set to false to disable default terminal tree previewer using `eza`/`tree`
-  -- You can also use your own previewer via `require("telescope").extensions.zoxide.list({ previewer = previewers.vim_buffer_cat.new({}) })`
-  use_default_previewer = true,
   show_score = true,
   -- See `:help telescope.defaults.path_display`
   path_display = function(opts, path)
@@ -57,7 +56,6 @@ local default_config = {
       transformed_path = "~/" .. Path:new(path):make_relative(home)
     end
     -- Truncate
-    -- Copied from: https://github.com/nvim-telescope/telescope.nvim/blob/bfcc7d5c6f12209139f175e6123a7b7de6d9c18a/lua/telescope/utils.lua#L198
     local calc_result_length = function(truncate_len)
       local status = get_status(vim.api.nvim_get_current_buf())
       local len = vim.api.nvim_win_get_width(status.layout.results.winid) - status.picker.selection_caret:len() - 2
@@ -79,6 +77,52 @@ local default_config = {
     }
     return transformed_path, path_style
   end,
+
+  -- Terminal previewer using `eza`/`tree`, set to nil to disable
+  previewer =  previewers.new_termopen_previewer({
+    title = "Tree Preview",
+    get_command = function(entry)
+      local p = from_entry.path(entry, true, false)
+      if p == nil or p == "" then
+        return
+      end
+      local command
+      local ignore_glob = ".DS_Store|.git|.svn|.idea|.vscode|node_modules"
+      if vim.fn.executable("eza") == 1 then
+        command = {
+          "eza",
+          "--all",
+          "--level=2",
+          "--group-directories-first",
+          "--ignore-glob=" .. ignore_glob,
+          "--git-ignore",
+          "--tree",
+          "--color=always",
+          "--color-scale",
+          "all",
+          "--icons=always",
+          "--long",
+          "--time-style=iso",
+          "--git",
+          "--no-permissions",
+          "--no-user",
+        }
+      else
+        command = { "tree", "-a", "-L", "2", "-I", ignore_glob, "-C", "--dirsfirst" }
+      end
+      return utils.flatten({ command, "--", utils.path_expand(p) })
+    end,
+    scroll_fn = function(self, direction)
+      if not self.state then
+        return
+      end
+      local input = vim.api.nvim_replace_termcodes(direction > 0 and "<C-e>" or "<C-y>", true, false, true)
+      local count = math.abs(direction)
+      vim.api.nvim_win_call(vim.fn.bufwinid(self.state.termopen_bufnr), function()
+        vim.cmd([[normal! ]] .. count .. input)
+      end)
+    end,
+  }),
 }
 
 local current_config = default_config

--- a/lua/telescope/_extensions/zoxide/config.lua
+++ b/lua/telescope/_extensions/zoxide/config.lua
@@ -1,8 +1,7 @@
-local Path = require("plenary.path")
 local builtin = require("telescope.builtin")
 local utils = require('telescope.utils')
-local previewers = require("telescope.previewers")
 local z_utils = require("telescope._extensions.zoxide.utils")
+local Path = require("plenary.path")
 
 local truncate = require("plenary.strings").truncate
 local get_status = require("telescope.state").get_status
@@ -11,40 +10,6 @@ local config = {}
 
 local default_config = {
   prompt_title = "[ Zoxide List ]",
-  -- set to `nil` to disable previewer
-  previewer = previewers.vim_buffer_cat.new,
-  show_score = true,
-  -- see `:help telescope.defaults.path_display`
-  path_display = function(opts, path)
-    local transformed_path = vim.trim(path)
-    -- replace home with ~
-    local home = vim.loop.os_homedir()
-    if home and vim.startswith(path, home) then
-      transformed_path = "~/" .. Path:new(path):make_relative(home)
-    end
-    -- truncate
-    -- copy from: https://github.com/nvim-telescope/telescope.nvim/blob/bfcc7d5c6f12209139f175e6123a7b7de6d9c18a/lua/telescope/utils.lua#L198
-    local calc_result_length = function(truncate_len)
-      local status = get_status(vim.api.nvim_get_current_buf())
-      local len = vim.api.nvim_win_get_width(status.layout.results.winid) - status.picker.selection_caret:len() - 2
-      return type(truncate_len) == "number" and len - truncate_len or len
-    end
-    local truncate_len = nil
-    if opts.__length == nil then
-      opts.__length = calc_result_length(truncate_len)
-    end
-    if opts.__prefix == nil then
-      opts.__prefix = 0
-    end
-    transformed_path = truncate(transformed_path, opts.__length - opts.__prefix, nil, -1)
-    -- filename highlighting
-    local tail = utils.path_tail(path)
-    local path_style = {
-      { { 0, #transformed_path - #tail }, "Comment" },
-      -- { { #transformed_path - #tail, #transformed_path }, "Constant" },
-    }
-    return transformed_path, path_style
-  end,
 
   -- Zoxide list command with score
   list_command = "zoxide query -ls",
@@ -77,7 +42,43 @@ local default_config = {
         vim.cmd.tcd(selection.path)
       end
     },
-  }
+  },
+
+  -- Set to false to disable default terminal tree previewer using `eza`/`tree`
+  -- You can also use your own previewer via `require("telescope").extensions.zoxide.list({ previewer = previewers.vim_buffer_cat.new({}) })`
+  use_default_previewer = true,
+  show_score = true,
+  -- See `:help telescope.defaults.path_display`
+  path_display = function(opts, path)
+    local transformed_path = vim.trim(path)
+    -- Replace home with ~
+    local home = vim.loop.os_homedir()
+    if home and vim.startswith(path, home) then
+      transformed_path = "~/" .. Path:new(path):make_relative(home)
+    end
+    -- Truncate
+    -- Copied from: https://github.com/nvim-telescope/telescope.nvim/blob/bfcc7d5c6f12209139f175e6123a7b7de6d9c18a/lua/telescope/utils.lua#L198
+    local calc_result_length = function(truncate_len)
+      local status = get_status(vim.api.nvim_get_current_buf())
+      local len = vim.api.nvim_win_get_width(status.layout.results.winid) - status.picker.selection_caret:len() - 2
+      return type(truncate_len) == "number" and len - truncate_len or len
+    end
+    local truncate_len = nil
+    if opts.__length == nil then
+      opts.__length = calc_result_length(truncate_len)
+    end
+    if opts.__prefix == nil then
+      opts.__prefix = 0
+    end
+    transformed_path = truncate(transformed_path, opts.__length - opts.__prefix, nil, -1)
+    -- Filename highlighting
+    local tail = utils.path_tail(path)
+    local path_style = {
+      { { 0, #transformed_path - #tail }, "Comment" },
+      -- { { #transformed_path - #tail, #transformed_path }, "Constant" },
+    }
+    return transformed_path, path_style
+  end,
 }
 
 local current_config = default_config

--- a/lua/telescope/_extensions/zoxide/config.lua
+++ b/lua/telescope/_extensions/zoxide/config.lua
@@ -7,6 +7,8 @@ local config = {}
 local default_config = {
   prompt_title = "[ Zoxide List ]",
 
+  replace_home_with_tilde = true,
+
   -- Zoxide list command with score
   list_command = "zoxide query -ls",
   mappings = {

--- a/lua/telescope/_extensions/zoxide/config.lua
+++ b/lua/telescope/_extensions/zoxide/config.lua
@@ -66,11 +66,10 @@ local default_config = {
       opts.__prefix = 0
     end
     transformed_path = truncate(transformed_path, opts.__length - opts.__prefix, nil, -1)
-    -- Filename highlighting
+    -- Dim parent directories
     local tail = utils.path_tail(path)
     local path_style = {
       { { 0, #transformed_path - #tail }, "Comment" },
-      -- { { #transformed_path - #tail, #transformed_path }, "TelescopeResultsIdentifier" },
     }
     return transformed_path, path_style
   end,

--- a/lua/telescope/_extensions/zoxide/config.lua
+++ b/lua/telescope/_extensions/zoxide/config.lua
@@ -1,7 +1,5 @@
 local builtin = require("telescope.builtin")
 local utils = require('telescope.utils')
-local previewers = require("telescope.previewers")
-local from_entry = require("telescope.from_entry")
 local z_utils = require("telescope._extensions.zoxide.utils")
 
 local truncate = require("plenary.strings").truncate

--- a/lua/telescope/_extensions/zoxide/config.lua
+++ b/lua/telescope/_extensions/zoxide/config.lua
@@ -73,52 +73,6 @@ local default_config = {
     }
     return transformed_path, path_style
   end,
-
-  -- Terminal previewer using `eza`/`tree`, can be disabled via `previewer = false`
-  previewer =  previewers.new_termopen_previewer({
-    title = "Tree Preview",
-    get_command = function(entry)
-      local p = from_entry.path(entry, true, false)
-      if p == nil or p == "" then
-        return
-      end
-      local command
-      local ignore_glob = ".DS_Store|.git|.svn|.idea|.vscode|node_modules"
-      if vim.fn.executable("eza") == 1 then
-        command = {
-          "eza",
-          "--all",
-          "--level=2",
-          "--group-directories-first",
-          "--ignore-glob=" .. ignore_glob,
-          "--git-ignore",
-          "--tree",
-          "--color=always",
-          "--color-scale",
-          "all",
-          "--icons=always",
-          "--long",
-          "--time-style=iso",
-          "--git",
-          "--no-permissions",
-          "--no-user",
-        }
-      else
-        command = { "tree", "-a", "-L", "2", "-I", ignore_glob, "-C", "--dirsfirst" }
-      end
-      return utils.flatten({ command, "--", utils.path_expand(p) })
-    end,
-    scroll_fn = function(self, direction)
-      if not self.state then
-        return
-      end
-      local input = vim.api.nvim_replace_termcodes(direction > 0 and "<C-e>" or "<C-y>", true, false, true)
-      local count = math.abs(direction)
-      vim.api.nvim_win_call(vim.fn.bufwinid(self.state.termopen_bufnr), function()
-        vim.cmd([[normal! ]] .. count .. input)
-      end)
-    end,
-  }),
 }
 
 local current_config = default_config

--- a/lua/telescope/_extensions/zoxide/config.lua
+++ b/lua/telescope/_extensions/zoxide/config.lua
@@ -47,7 +47,9 @@ local default_config = {
     -- Truncate
     local calc_result_length = function(truncate_len)
       local status = get_status(vim.api.nvim_get_current_buf())
-      local len = vim.api.nvim_win_get_width(status.layout.results.winid) - status.picker.selection_caret:len() - 2
+      -- Compatibility with telescope.nvim 0.1.4
+      local results_win = vim.tbl_get(status, "layout", "results", "winid") or status.results_win
+      local len = vim.api.nvim_win_get_width(results_win) - status.picker.selection_caret:len() - 2
       return type(truncate_len) == "number" and len - truncate_len or len
     end
     local truncate_len = nil

--- a/lua/telescope/_extensions/zoxide/list.lua
+++ b/lua/telescope/_extensions/zoxide/list.lua
@@ -3,6 +3,7 @@ local action_state = require('telescope.actions.state')
 local finders = require('telescope.finders')
 local pickers = require('telescope.pickers')
 local sorters = require('telescope.sorters')
+local previewers = require("telescope.previewers")
 local utils = require('telescope.utils')
 
 local z_config = require("telescope._extensions.zoxide.config")
@@ -121,6 +122,7 @@ return function(opts)
       entry_maker = entry_maker
     },
     sorter = fuzzy_with_z_score_bias(opts),
+    previewer = z_config.get_config().previewer and previewers.vim_buffer_cat.new(opts) or nil,
     attach_mappings = function(prompt_bufnr, map)
       local mappings = z_config.get_config().mappings
 

--- a/lua/telescope/_extensions/zoxide/list.lua
+++ b/lua/telescope/_extensions/zoxide/list.lua
@@ -7,8 +7,6 @@ local previewers = require("telescope.previewers")
 local entry_display = require('telescope.pickers.entry_display')
 local utils = require('telescope.utils')
 
-local get_status = require("telescope.state").get_status
-
 local z_config = require("telescope._extensions.zoxide.config")
 
 local map_both = function(map, keys, func)
@@ -75,17 +73,6 @@ local entry_maker = function(item)
     local home = vim.loop.os_homedir()
     if z_config.get_config().replace_home_with_tilde and home and vim.startswith(path, home) then
       path = "~/" .. require("plenary.path"):new(path):make_relative(home)
-    end
-    -- truncate
-    if z_config.get_config().truncate then
-      -- copy from: https://github.com/nvim-telescope/telescope.nvim/blob/bfcc7d5c6f12209139f175e6123a7b7de6d9c18a/lua/telescope/utils.lua#L198
-      local calc_result_length = function(truncate_len)
-        local status = get_status(vim.api.nvim_get_current_buf())
-        local len = vim.api.nvim_win_get_width(status.layout.results.winid) - status.picker.selection_caret:len() - 2
-        return type(truncate_len) == "number" and len - truncate_len or len
-      end
-      local truncate_len = nil
-      path = require("plenary.strings").truncate(path, calc_result_length(truncate_len), nil, -1)
     end
     return path
   end

--- a/lua/telescope/_extensions/zoxide/list.lua
+++ b/lua/telescope/_extensions/zoxide/list.lua
@@ -5,6 +5,8 @@ local pickers = require('telescope.pickers')
 local sorters = require('telescope.sorters')
 local utils = require('telescope.utils')
 
+local z_config = require("telescope._extensions.zoxide.config")
+
 local map_both = function(map, keys, func)
       map("i", keys, func)
       map("n", keys, func)
@@ -64,10 +66,20 @@ local entry_maker = function(item)
   local item_path = string.gsub(trimmed, '^[^%s]* (.*)$', '%1')
   local score = tonumber(string.gsub(trimmed, '^([^%s]*) .*$', '%1'), 10)
 
+  local replace_home_with_tilde = z_config.get_config().replace_home_with_tilde
+
+  local path_display = function(path)
+    local home = vim.loop.os_homedir()
+    if replace_home_with_tilde and vim.startswith(path, home) then
+      return "~/" .. require("plenary.path"):new(path):make_relative(home)
+    end
+    return path
+  end
+
   return {
     value = item_path,
     ordinal = item_path,
-    display = item_path,
+    display = path_display(item_path),
     z_score = score,
     path = item_path
   }
@@ -94,7 +106,6 @@ end
 return function(opts)
   opts = opts or {}
 
-  local z_config = require("telescope._extensions.zoxide.config")
   local cmd = z_config.get_config().list_command
   local shell_arg = "-c"
   if vim.o.shell == "cmd.exe" then

--- a/lua/telescope/_extensions/zoxide/list.lua
+++ b/lua/telescope/_extensions/zoxide/list.lua
@@ -3,8 +3,6 @@ local action_state = require('telescope.actions.state')
 local finders = require('telescope.finders')
 local pickers = require('telescope.pickers')
 local sorters = require('telescope.sorters')
-local previewers = require("telescope.previewers")
-local from_entry = require("telescope.from_entry")
 local entry_display = require('telescope.pickers.entry_display')
 local utils = require('telescope.utils')
 
@@ -123,51 +121,6 @@ local entry_maker = function(opts)
   end
 end
 
-local tree_previewer = previewers.new_termopen_previewer({
-  title = "Tree Preview",
-  get_command = function(entry)
-    local p = from_entry.path(entry, true, false)
-    if p == nil or p == "" then
-      return
-    end
-    local command
-    local ignore_glob = ".DS_Store|.git|.svn|.idea|.vscode|node_modules"
-    if vim.fn.executable("eza") == 1 then
-      command = {
-        "eza",
-        "--all",
-        "--level=2",
-        "--group-directories-first",
-        "--ignore-glob=" .. ignore_glob,
-        "--git-ignore",
-        "--tree",
-        "--color=always",
-        "--color-scale",
-        "all",
-        "--icons=always",
-        "--long",
-        "--time-style=iso",
-        "--git",
-        "--no-permissions",
-        "--no-user",
-      }
-    else
-      command = { "tree", "-a", "-L", "2", "-I", ignore_glob, "-C", "--dirsfirst" }
-    end
-    return utils.flatten({ command, "--", utils.path_expand(p) })
-  end,
-  scroll_fn = function(self, direction)
-    if not self.state then
-      return
-    end
-    local input = vim.api.nvim_replace_termcodes(direction > 0 and "<C-e>" or "<C-y>", true, false, true)
-    local count = math.abs(direction)
-    vim.api.nvim_win_call(vim.fn.bufwinid(self.state.termopen_bufnr), function()
-      vim.cmd([[normal! ]] .. count .. input)
-    end)
-  end,
-})
-
 local create_mapping = function(prompt_bufnr, mapping_config)
   return function()
     local selection = action_state.get_selected_entry()
@@ -205,7 +158,7 @@ return function(opts)
     },
     sorter = fuzzy_with_z_score_bias(opts),
     path_display = z_config.get_config().path_display,
-    previewer = z_config.get_config().use_default_previewer and tree_previewer or nil,
+    previewer = z_config.get_config().previewer,
     attach_mappings = function(prompt_bufnr, map)
       local mappings = z_config.get_config().mappings
 

--- a/lua/telescope/_extensions/zoxide/list.lua
+++ b/lua/telescope/_extensions/zoxide/list.lua
@@ -148,6 +148,7 @@ return function(opts)
     shell_arg = "/c"
   end
   opts.cmd = vim.F.if_nil(opts.cmd, {vim.o.shell, shell_arg, cmd})
+  opts.path_display = vim.F.if_nil(opts.path_display, z_config.get_config().path_display)
 
   pickers.new(opts, {
     prompt_title = z_config.get_config().prompt_title,
@@ -157,7 +158,6 @@ return function(opts)
       entry_maker = entry_maker(opts)
     },
     sorter = fuzzy_with_z_score_bias(opts),
-    path_display = z_config.get_config().path_display,
     previewer = z_config.get_config().previewer,
     attach_mappings = function(prompt_bufnr, map)
       local mappings = z_config.get_config().mappings

--- a/lua/telescope/_extensions/zoxide/list.lua
+++ b/lua/telescope/_extensions/zoxide/list.lua
@@ -69,12 +69,9 @@ local entry_maker = function(opts)
     local item_path = string.gsub(trimmed, '^[^%s]* (.*)$', '%1')
     local score = tonumber(string.gsub(trimmed, '^([^%s]*) .*$', '%1'), 10)
 
-    local display_path, path_style = utils.transform_path(opts, item_path)
-
     local display_items = {
       { remaining = true },
     }
-
     local show_score = z_config.get_config().show_score
     if show_score then
       table.insert(display_items, 1, { width = 7, right_justify = true })
@@ -86,6 +83,7 @@ local entry_maker = function(opts)
     })
 
     local make_display = function()
+      local display_path, path_style = utils.transform_path(opts, item_path)
       if show_score then
         return displayer {
           { ("%.2f"):format(score), "TelescopeResultsNumber" },

--- a/lua/telescope/_extensions/zoxide/list.lua
+++ b/lua/telescope/_extensions/zoxide/list.lua
@@ -146,7 +146,6 @@ return function(opts)
       entry_maker = entry_maker(opts)
     },
     sorter = fuzzy_with_z_score_bias(opts),
-    previewer = z_config.get_config().previewer,
     attach_mappings = function(prompt_bufnr, map)
       local mappings = z_config.get_config().mappings
 


### PR DESCRIPTION
- Add default `path_display` to:
  1.  Replace home dir with `~` to make path shorter.
  2. Truncate long path.
  3.  Filename highlighting.
- Add `show_score` opt, default to true.
- Add `previewer` opt, uses terminal tree previewer via `eza`/`tree`, can be disabled by user via `previewer = false`.

<img width="1600" alt="zoxide-preview" src="https://github.com/user-attachments/assets/bcbc52b0-a76e-47e0-846c-7746c2d57f22">

Copied some codes from gczcn's [fork](https://github.com/gczcn/telescope-zoxide), [telescope-z.nvim](https://github.com/nvim-telescope/telescope-z.nvim) and petobens's [dotfiles](https://github.com/petobens/dotfiles/blob/0e216cdf8048859db5cbec0a1bc5b99d45479817/nvim/lua/plugin-config/telescope_config.lua#L784).

Edit: The `previewer` in this PR has removed since we already add a previewer in [#16](https://github.com/jvgrootveld/telescope-zoxide/pull/16).