### PR TITLE
Add hint to `list_command` and troubleshooting

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ t.setup({
   extensions = {
     zoxide = {
       prompt_title = "[ Walking on the shoulders of TJ ]",
+      list_command = "zoxide query --list --score --all",
       mappings = {
         default = {
           after_action = function(selection)
@@ -189,3 +190,13 @@ This action requires installing the [Telescope file browser extension](https://g
   }
 }
 ```
+
+## Troubleshooting
+
+### Slow listing or empty listing/timeout
+
+zoxides query command can be quiet slow when working with remote storage [Issue
+#406](https://github.com/ajeetdsouza/zoxide/issues/406). In this case a
+workaround is to use the environment variale `_ZO_EXCLUDE_DIRS` or
+`list_command= "zoxide query --list --score --all"` in the config of Telescope
+Zoxide.


### PR DESCRIPTION
Added a hint to `list_command` configuration in the example configuration. Also add a section Troubleshooting with hint for a solution when the listing is slow or times out.

I run in the problem that opening the list got slow and slower until I ran into a time out. I figured out, that this is a problem with zoxide itself [Issue #406](https://github.com/ajeetdsouza/zoxide/issues/406). So as a suggestion I added Infos in the README.md.

As an alternative the argument `-a` / `--all` could be added to the `zoxide query` command by default. If this is preferred, I would do the work.