### PR TITLE
Improved support for powershell & pwsh (Powershell 7+)

### DIFF
--- a/lua/telescope/_extensions/zoxide/list.lua
+++ b/lua/telescope/_extensions/zoxide/list.lua
@@ -99,7 +99,7 @@ return function(opts)
 
   local shell_cmd
   if vim.o.shell:match('pwsh') or vim.o.shell:match('powershell') then
-    shell_cmd = { vim.o.shell, '-NoLogo', '-NoProfile', '-Command', cmd }
+    shell_cmd = { vim.o.shell, '-NoLogo', '-NonInteractive', '-NoProfile', '-Command', cmd }
   elseif vim.o.shell:match("cmd") then
     shell_cmd = { vim.o.shell, '/c', cmd }
   else

--- a/lua/telescope/_extensions/zoxide/list.lua
+++ b/lua/telescope/_extensions/zoxide/list.lua
@@ -98,9 +98,9 @@ return function(opts)
   local cmd = z_config.get_config().list_command
 
   local shell_cmd
-  if vim.o.shell == 'pwsh' or vim.o.shell == 'powershell' then
+  if vim.o.shell:match('pwsh') or vim.o.shell:match('powershell') then
     shell_cmd = { vim.o.shell, '-NoLogo', '-NoProfile', '-Command', cmd }
-  elseif vim.o.shell == "cmd.exe" then
+  elseif vim.o.shell:match("cmd") then
     shell_cmd = { vim.o.shell, '/c', cmd }
   else
     shell_cmd = { vim.o.shell, '-c', cmd }

--- a/lua/telescope/_extensions/zoxide/list.lua
+++ b/lua/telescope/_extensions/zoxide/list.lua
@@ -96,11 +96,17 @@ return function(opts)
 
   local z_config = require("telescope._extensions.zoxide.config")
   local cmd = z_config.get_config().list_command
-  local shell_arg = "-c"
-  if vim.o.shell == "cmd.exe" then
-    shell_arg = "/c"
+
+  local shell_cmd
+  if vim.o.shell == 'pwsh' or vim.o.shell == 'powershell' then
+    shell_cmd = { vim.o.shell, '-NoLogo', '-NoProfile', '-Command', cmd }
+  elseif vim.o.shell == "cmd.exe" then
+    shell_cmd = { vim.o.shell, '/c', cmd }
+  else
+    shell_cmd = { vim.o.shell, '-c', cmd }
   end
-  opts.cmd = vim.F.if_nil(opts.cmd, {vim.o.shell, shell_arg, cmd})
+
+  opts.cmd = vim.F.if_nil(opts.cmd, shell_cmd)
 
   pickers.new(opts, {
     prompt_title = z_config.get_config().prompt_title,


### PR DESCRIPTION
Unlike bash, PowerShell loads the profile by default, so it can be (alot) slower. We disable this with the `-NoProfile` flag.

Also updated the shell check to use pattern matching because some people may set their `vim.o.shell` to:
- `pwsh`
- `pwsh.exe`
- `full/path/to/pwsh.exe`